### PR TITLE
CMakeのバージョンアップ対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.13)
 
 include_directories(include)
 


### PR DESCRIPTION
Warning at lib/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

上記の警告が出るため、バージョンアップを行いました。